### PR TITLE
Fix #23 useBundles: false option throws an exception for systemjs@0.20

### DIFF
--- a/src/files/default-adapter.js
+++ b/src/files/default-adapter.js
@@ -47,7 +47,9 @@
 
     // Exclude bundle configurations if useBundles option is not specified
     if (!karma.config.jspm.useBundles) {
-      System.bundles = [];
+      System.config({
+        bundles: []
+      });
     }
 
 


### PR DESCRIPTION
The method for setting bundles changed May 2015 here (tagged systemjs@0.17):
systemjs/systemjs@2141c64